### PR TITLE
Some Housekeeping and PreviewModifier to Populate Previews with Data

### DIFF
--- a/CubeSight.xcodeproj/project.pbxproj
+++ b/CubeSight.xcodeproj/project.pbxproj
@@ -61,7 +61,7 @@
 		78980A532B7D270400E89E68 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		78980A562B7D2D5A00E89E68 /* CubeCobraClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CubeCobraClient.swift; sourceTree = "<group>"; };
 		78980A5C2B7D388500E89E68 /* ImportCubeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportCubeView.swift; sourceTree = "<group>"; };
-		78980A5E2B7D452D00E89E68 /* CubeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CubeView.swift; sourceTree = "<group>"; };
+		78980A5E2B7D452D00E89E68 /* CubeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CubeView.swift; sourceTree = "<group>"; wrapsLines = 1; };
 		78B8835C2B82AC0D00F099AB /* CardList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardList.swift; sourceTree = "<group>"; };
 		78B8835F2B82ADFE00F099AB /* CardRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardRow.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -113,7 +113,10 @@
 				7883C50F2B7C0EB80087EAB7 /* CubeSightUITests */,
 				7883C4F12B7C0EB70087EAB7 /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
+			wrapsLines = 0;
 		};
 		7883C4F12B7C0EB70087EAB7 /* Products */ = {
 			isa = PBXGroup;

--- a/CubeSight.xcodeproj/project.pbxproj
+++ b/CubeSight.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		46B2FA012C43C7AD007794D9 /* TextRecognitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B2FA002C43C7AA007794D9 /* TextRecognitionView.swift */; };
 		46BE65AD2D0F4553005F062B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BE65AC2D0F4553005F062B /* ContentView.swift */; };
+		786539B62D1DF6ED00BA056D /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786539B52D1DF6ED00BA056D /* SampleData.swift */; };
 		7883C4F42B7C0EB70087EAB7 /* CubeSightApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7883C4F32B7C0EB70087EAB7 /* CubeSightApp.swift */; };
 		7883C4F62B7C0EB70087EAB7 /* CubeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7883C4F52B7C0EB70087EAB7 /* CubeContentView.swift */; };
 		7883C4FA2B7C0EB80087EAB7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7883C4F92B7C0EB80087EAB7 /* Assets.xcassets */; };
@@ -45,6 +46,7 @@
 /* Begin PBXFileReference section */
 		46B2FA002C43C7AA007794D9 /* TextRecognitionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognitionView.swift; sourceTree = "<group>"; };
 		46BE65AC2D0F4553005F062B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		786539B52D1DF6ED00BA056D /* SampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
 		7883C4F02B7C0EB70087EAB7 /* CubeSight.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CubeSight.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7883C4F32B7C0EB70087EAB7 /* CubeSightApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CubeSightApp.swift; sourceTree = "<group>"; };
 		7883C4F52B7C0EB70087EAB7 /* CubeContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CubeContentView.swift; sourceTree = "<group>"; };
@@ -103,6 +105,14 @@
 			path = Cube;
 			sourceTree = "<group>";
 		};
+		786539B42D1DF6D500BA056D /* Preview */ = {
+			isa = PBXGroup;
+			children = (
+				786539B52D1DF6ED00BA056D /* SampleData.swift */,
+			);
+			path = Preview;
+			sourceTree = "<group>";
+		};
 		7883C4E72B7C0EB70087EAB7 = {
 			isa = PBXGroup;
 			children = (
@@ -131,6 +141,7 @@
 		7883C4F22B7C0EB70087EAB7 /* CubeSight */ = {
 			isa = PBXGroup;
 			children = (
+				786539B42D1DF6D500BA056D /* Preview */,
 				46BE65AB2D0F44BF005F062B /* Cube */,
 				78980A502B7D248500E89E68 /* Data */,
 				78B8835E2B82ADE200F099AB /* Card */,
@@ -325,6 +336,7 @@
 				78980A5D2B7D388500E89E68 /* ImportCubeView.swift in Sources */,
 				78980A572B7D2D5A00E89E68 /* CubeCobraClient.swift in Sources */,
 				7883C4F42B7C0EB70087EAB7 /* CubeSightApp.swift in Sources */,
+				786539B62D1DF6ED00BA056D /* SampleData.swift in Sources */,
 				78980A5F2B7D452D00E89E68 /* CubeView.swift in Sources */,
 				78B883602B82ADFE00F099AB /* CardRow.swift in Sources */,
 				78B8835D2B82AC0D00F099AB /* CardList.swift in Sources */,

--- a/CubeSight/Card/CardList.swift
+++ b/CubeSight/Card/CardList.swift
@@ -26,6 +26,7 @@ struct CardList: View {
   }
 }
 
-#Preview {
-  CardList(cubeId: "")
+@available(iOS 18.0, *)
+#Preview(traits: .sampleData) {
+  CardList(cubeId: Cube.sampleCube.id)
 }

--- a/CubeSight/Card/CardRow.swift
+++ b/CubeSight/Card/CardRow.swift
@@ -25,12 +25,6 @@ struct CardRow: View {
 }
 
 #Preview {
-  CardRow(
-    card: Card(
-      id: UUID(), name: "XYZ", imageSmall: "",
-      imageNormal:
-        "https://cards.scryfall.io/normal/front/a/2/a24e8dba-5c86-4e32-8a52-61402f7fe9f0.jpg?1594734854",
-      colors: [.black], manaValue: 2, colorcategory: .black)
-  )
-  .padding()
+  CardRow(card: Card.blackLotus)
+    .padding()
 }

--- a/CubeSight/ContentView.swift
+++ b/CubeSight/ContentView.swift
@@ -1,10 +1,3 @@
-//
-//  ContentView.swift
-//  CubeSight
-//
-//  Created by Noe on 15.12.2024.
-//
-
 import SwiftUI
 
 struct ContentView: View {
@@ -21,9 +14,9 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView()
+  ContentView()
 }
 
 enum Tab {
-    case cube
+  case cube
 }

--- a/CubeSight/Cube/CubeContentView.swift
+++ b/CubeSight/Cube/CubeContentView.swift
@@ -39,7 +39,7 @@ struct CubeContentView: View {
 
 }
 
-#Preview {
+@available(iOS 18.0, *)
+#Preview(traits: .sampleData) {
   CubeContentView()
-    .modelContainer(for: [Card.self, Cube.self], inMemory: true)
 }

--- a/CubeSight/Cube/CubeView.swift
+++ b/CubeSight/Cube/CubeView.swift
@@ -35,6 +35,7 @@ struct CubeView: View {
   }
 }
 
-#Preview {
-  CubeView(cube: Cube(id: "", shortId: "", name: "Sample Cube"))
+@available(iOS 18.0, *)
+#Preview(traits: .sampleData) {
+  CubeView(cube: Cube.sampleCube)
 }

--- a/CubeSight/Cube/ImportCubeView.swift
+++ b/CubeSight/Cube/ImportCubeView.swift
@@ -55,9 +55,9 @@ struct ImportCubeView: View {
   }
 }
 
-#Preview {
+@available(iOS 18.0, *)
+#Preview(traits: .sampleData) {
   NavigationStack {
     ImportCubeView(shortId: "dimlas3")
   }
-  .modelContainer(for: [Card.self, Cube.self], inMemory: true)
 }

--- a/CubeSight/Cube/TextRecognitionView.swift
+++ b/CubeSight/Cube/TextRecognitionView.swift
@@ -252,7 +252,7 @@ struct TextRecognitionView: View {
   }
 }
 
-#Preview {
+@available(iOS 18.0, *)
+#Preview(traits: .sampleData) {
   TextRecognitionView()
-    .modelContainer(for: [Card.self, Cube.self], inMemory: true)
 }

--- a/CubeSight/Data/Card.swift
+++ b/CubeSight/Data/Card.swift
@@ -105,3 +105,17 @@ extension Card {
     }
   }
 }
+
+extension Card {
+  static let blackLotus = Card(
+    id: UUID(uuidString: "bd8fa327-dd41-4737-8f19-2cf5eb1f7cdd")!,
+    name: "Black Lotus",
+    imageSmall:
+      "https://cards.scryfall.io/small/front/b/d/bd8fa327-dd41-4737-8f19-2cf5eb1f7cdd.jpg?1614638838",
+    imageNormal:
+      "https://cards.scryfall.io/normal/front/b/d/bd8fa327-dd41-4737-8f19-2cf5eb1f7cdd.jpg?1614638838",
+    colors: [],
+    manaValue: 0,
+    colorcategory: .colorless
+  )
+}

--- a/CubeSight/Data/Cube.swift
+++ b/CubeSight/Data/Cube.swift
@@ -15,3 +15,14 @@ import SwiftData
     self.name = name
   }
 }
+
+extension Cube {
+  static let sampleCube = Cube(id: UUID().uuidString, shortId: "dimlas4", name: "Vintage Cube")
+
+  @MainActor
+  static func makeSampleCube(in context: ModelContainer) {
+    context.mainContext.insert(Card.blackLotus)
+    sampleCube.mainboard = [Card.blackLotus]
+    context.mainContext.insert(sampleCube)
+  }
+}

--- a/CubeSight/Preview/SampleData.swift
+++ b/CubeSight/Preview/SampleData.swift
@@ -1,0 +1,21 @@
+import SwiftData
+import SwiftUI
+
+struct SampleData: PreviewModifier {
+
+  static func makeSharedContext() async throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(for: Cube.self, Card.self, configurations: config)
+    Cube.makeSampleCube(in: container)
+    return container
+  }
+
+  func body(content: Content, context: ModelContainer) -> some View {
+    content.modelContainer(context)
+  }
+}
+
+extension PreviewTrait where T == Preview.ViewTraits {
+  @available(iOS 18.0, *)
+  @MainActor static var sampleData: Self = .modifier(SampleData())
+}


### PR DESCRIPTION
The following changes were made:

* Added a new `PreviewModifier` to provide sample data for previews ([see "What's new in SwiftData"](https://developer.apple.com/videos/play/wwdc2024/10137?time=418)).
* Configured the project to use 2 spaces for indentation. This is the same as the default for [swift-format](https://github.com/swiftlang/swift-format/blob/main/Documentation/Configuration.md#indentation).
* Minor cleanup: e.g. remove header comment and reformat.